### PR TITLE
Disables wrap when a pattern is found

### DIFF
--- a/lua/cloak/init.lua
+++ b/lua/cloak/init.lua
@@ -76,7 +76,7 @@ M.cloak = function(cloak_pattern)
     end
   end
   if found_pattern then
-    vim.opt.wrap = false
+    vim.opt_local.wrap = false
   end
 end
 

--- a/lua/cloak/init.lua
+++ b/lua/cloak/init.lua
@@ -53,12 +53,14 @@ M.cloak = function(cloak_pattern)
     require('cmp').setup.buffer({ enabled = false })
   end
 
+  local found_pattern = false
   local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
   for i, line in ipairs(lines) do
     for _, pattern in ipairs(cloak_pattern) do
       local first, last = line:find(pattern)
 
       if first ~= nil then
+        found_pattern = true
         vim.api.nvim_buf_set_extmark(
           0, namespace, i - 1, first, {
             virt_text = {
@@ -72,6 +74,9 @@ M.cloak = function(cloak_pattern)
         )
       end
     end
+  end
+  if found_pattern then
+    vim.opt.wrap = false
   end
 end
 


### PR DESCRIPTION
This change will disable line wrapping when a pattern is found. Currently, it looks like it isn't possible to show virtual text on wrapped lines, so this is the next best option...