### PR TITLE
feat: add cloak length

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ It also disables 'cmp' for the buffer(if it is installed).
 
 Here is the default configuration.
 
-'file_pattern' can be a string or table of strings, they should be valid autocommand patterns.
-'cloak_pattern' is a lua pattern ran over every line in the buffer,
-overlaying 'cloak_character' over the match, excluding the first character.
+- `file_pattern` can be a string or table of strings, they should be valid autocommand patterns.
+- `cloak_pattern` is a lua pattern ran over every line in the buffer,
+overlaying `cloak_character` over the match, excluding the first character.
 
 ```lua
 require('cloak').setup({
@@ -22,6 +22,9 @@ require('cloak').setup({
   cloak_character = '*',
   -- The applied highlight group (colors) on the cloaking, see `:h highlight`.
   highlight_group = 'Comment',
+  -- Applies the length of the replacement characters for all matched
+  -- patterns, defaults to the length of the matched pattern.
+  cloak_length = nil, -- Provide a number if you want to hide the true length of the value. 
   patterns = {
     {
       -- Match any file starting with '.env'.

--- a/lua/cloak/init.lua
+++ b/lua/cloak/init.lua
@@ -12,6 +12,7 @@ local M = {}
 M.opts = {
   enabled = true,
   cloak_character = '*',
+  cloak_length = nil,
   highlight_group = 'Comment',
   patterns = { { file_pattern = '.env*', cloak_pattern = '=.+' } },
 }
@@ -53,6 +54,14 @@ M.cloak = function(cloak_pattern)
     require('cmp').setup.buffer({ enabled = false })
   end
 
+  local function determine_pattern(first_line, last_line)
+    if tonumber(M.opts.cloak_length) ~= nil then
+      return string.rep(M.opts.cloak_character, M.opts.cloak_length)..string.rep(' ', last_line - first_line)
+    else
+      return string.rep(M.opts.cloak_character, last_line - first_line)
+    end
+  end
+
   local found_pattern = false
   local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
   for i, line in ipairs(lines) do
@@ -63,9 +72,10 @@ M.cloak = function(cloak_pattern)
         found_pattern = true
         vim.api.nvim_buf_set_extmark(
           0, namespace, i - 1, first, {
+            hl_mode = 'combine',
             virt_text = {
               {
-                string.rep(M.opts.cloak_character, last - first),
+                determine_pattern(first, last),
                 M.opts.highlight_group,
               },
             },

--- a/lua/cloak/init.lua
+++ b/lua/cloak/init.lua
@@ -54,11 +54,11 @@ M.cloak = function(cloak_pattern)
     require('cmp').setup.buffer({ enabled = false })
   end
 
-  local function determine_pattern(first_line, last_line)
+  local function determine_replacement(first_col, last_col)
     if tonumber(M.opts.cloak_length) ~= nil then
-      return string.rep(M.opts.cloak_character, M.opts.cloak_length)..string.rep(' ', last_line - first_line)
+      return string.rep(M.opts.cloak_character, M.opts.cloak_length)..string.rep(' ', last_col - first_col)
     else
-      return string.rep(M.opts.cloak_character, last_line - first_line)
+      return string.rep(M.opts.cloak_character, last_col - first_col)
     end
   end
 
@@ -75,7 +75,7 @@ M.cloak = function(cloak_pattern)
             hl_mode = 'combine',
             virt_text = {
               {
-                determine_pattern(first, last),
+                determine_replacement(first, last),
                 M.opts.highlight_group,
               },
             },


### PR DESCRIPTION
Sets the max number of characters that will appear on the cloak, no matter how many total chars it may have from the `cloak_length`. This is effectively a mask to hide the total amount of chars a value might have -- it helps to keep hidden what the value might contain.

It's api is providing a number to the `cloak_length` field on the setup table. If the value was not provided or the value is other than a number then Cloak will keep its original behavior.

For example, if the provided `cloak_length` is `10`:
![Screenshot 2023-03-23 at 10 53 54](https://user-images.githubusercontent.com/60858198/227243270-24348842-630e-4415-b8b2-966a0001dd30.png)

Without it:
![Screenshot 2023-03-23 at 10 55 04](https://user-images.githubusercontent.com/60858198/227243401-ba684dc5-39a6-4fe4-b7f1-d16cb7de7787.png)

The `hl_mode = 'combine'` option was added to respect the line and col highlights, without that it was pretty obvious (visually) what the length might be.