### PR TITLE
feat: add line preview function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ The plugin automatically activates when a file matched by the patterns is opened
 You do have to call the `setup()` function.
 
 `:CloakDisable`, `:CloakEnable` and `:CloakToggle` are also available to change cloaking state.
+
+Additionally, you can use `:CloakPreviewLine` to uncloak the line under the cursor.
+The cloak gets reapplied when you move your cursor to a different line.

--- a/lua/cloak/init.lua
+++ b/lua/cloak/init.lua
@@ -49,7 +49,7 @@ M.setup = function(opts)
   vim.api.nvim_create_user_command('CloakEnable', M.enable, {})
   vim.api.nvim_create_user_command('CloakDisable', M.disable, {})
   vim.api.nvim_create_user_command('CloakToggle', M.toggle, {})
-  vim.api.nvim_create_user_command('CloakPreviewLine', M.uncloakline, {})
+  vim.api.nvim_create_user_command('CloakPreviewLine', M.uncloak_line, {})
 end
 
 M.uncloak = function()

--- a/lua/cloak/init.lua
+++ b/lua/cloak/init.lua
@@ -86,6 +86,7 @@ M.uncloak_line = function()
             opts.buf, namespace, extmark[2], extmark[3], data
           )
         end
+        // deletes the auto command
         return true
       end,
       group = group,

--- a/lua/cloak/init.lua
+++ b/lua/cloak/init.lua
@@ -56,7 +56,7 @@ M.uncloak = function()
   vim.api.nvim_buf_clear_namespace(0, namespace, 0, -1)
 end
 
-M.uncloakline = function()
+M.uncloak_line = function()
   local buf = vim.api.nvim_win_get_buf(0)
   local cursor = vim.api.nvim_win_get_cursor(0)
   local startr = { cursor[1] - 1, 0 }


### PR DESCRIPTION
This PR adds a feature to allow the user to preview the cloaked line. It adds a new User command `CloakPreviewline` that when enabled shows the hidden text under the cursor (if there is any). It also creates an autocmd so that when the cursor is moved to a different line, the cloak is re-enabled (note: moving horizontally does not re-enable the cloak).