### PR TITLE
Disable cloak in telescope if required feature is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ require('cloak').setup({
   cloak_length = nil, -- Provide a number if you want to hide the true length of the value.
   -- Whether it should try every pattern to find the best fit or stop after the first.
   try_all_patterns = true,
-  -- Set to true to cloak Telescope preview buffers.
+  -- Set to true to cloak Telescope preview buffers. (Required feature not in 0.1.x)
   cloak_telescope = true,
   patterns = {
     {

--- a/lua/cloak/init.lua
+++ b/lua/cloak/init.lua
@@ -53,7 +53,8 @@ M.setup = function(opts)
       'User', {
         pattern = 'TelescopePreviewerLoaded',
         callback = function(args)
-          if not M.opts.enabled then
+          -- Feature not in 0.1.x
+          if not M.opts.enabled or args.data == nil then
             return
           end
 


### PR DESCRIPTION
The commit missing from `0.1.x` is nvim-telescope/telescope.nvim@80eefd8ff00145ef6ca4b7c64ef355b224f6e630
Fixes #15.