### PR TITLE
feat: cloak_on_leave

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ require('cloak').setup({
   try_all_patterns = true,
   -- Set to true to cloak Telescope preview buffers. (Required feature not in 0.1.x)
   cloak_telescope = true,
+  -- Re-enable cloak when a matched buffer leaves the window.
+  cloak_on_leave = false,
   patterns = {
     {
       -- Match any file starting with '.env'.

--- a/lua/cloak/init.lua
+++ b/lua/cloak/init.lua
@@ -18,6 +18,7 @@ M.opts = {
   patterns = { { file_pattern = '.env*', cloak_pattern = '=.+' } },
   cloak_telescope = true,
   uncloaked_line_num = nil,
+  cloak_on_leave = false,
 }
 
 M.setup = function(opts)
@@ -35,6 +36,7 @@ M.setup = function(opts)
             or inner_pattern
       end
     end
+
     vim.api.nvim_create_autocmd(
       { 'BufRead', 'TextChanged', 'TextChangedI', 'TextChangedP' }, {
         pattern = pattern.file_pattern,
@@ -46,10 +48,21 @@ M.setup = function(opts)
         group = group,
       }
     )
+
+    if M.opts.cloak_on_leave then
+      vim.api.nvim_create_autocmd(
+        'BufWinLeave', {
+          pattern = pattern.file_pattern,
+          callback = function()
+            M.enable()
+          end,
+          group = group,
+        }
+      )
+    end
   end
 
   if M.opts.cloak_telescope then
-
     vim.api.nvim_create_autocmd(
       'User', {
         pattern = 'TelescopePreviewerLoaded',


### PR DESCRIPTION

# New Option: `cloak_on_leave`

The other day I was making updates in an `.env` with Cloak toggled off before navigating away and working on other things. Later, I was meeting with someone and while jumping around my files I realized that my secrets weren't being cloaked because I forgot to re-enable the plugin!

Thankfully the other person had the same privileges as me so it wasn't a problem, but it easily could be depending on who you're sharing your screen with and what you're cloaking.

This commit adds a new boolean option `cloak_on_leave`, as well as the following code to the setup function:
```lua
if M.opts.cloak_on_leave then
  vim.api.nvim_create_autocmd(
    'BufWinLeave', {
      pattern = pattern.file_pattern,
      callback = function()
        M.enable()
      end,
      group = group,
    }
  )
end
```
This option ensures that if the buffer leaves the window Cloak will be re-enabled. That way when you're done working with secrets you don't have to spend time thinking or worrying about plugin commands and can just move onto the next task knowing everything will be cloaked.



# Resolved Issues
While I was testing `cloak_on_leave` I found some bugs that have been patched (f478abf) and documented below. 

There are 3 core issues:

1. Pre-existing buffers do not have their Cloak State changed if Cloak is toggled in a different buffer.
	A. **Cloaking previous buffers**
	B. **Uncloaking previous buffers**
	
2. Uncloaking lines and then switching buffers can leak secrets.
	A. **`CloakPreviewLine` & Split buffers**
	B. **`CloakPreviewLine` & Other buffers**
	
3. Uncloaking a line and then immediately disabling Cloak will cloak the entire file and desync `Cloak.enabled` from the drawing state.

When I say that the `Cloak.enabled` status is out of sync with the drawing, what I mean is that the state of the terminal shows cloaked characters but `Cloak.enabled` is False (or vice versa). This can lead to scenarios where `CloakPreviewLine` fails even though it looks like it should work, and you have to run `CloakToggle` twice / `CloakEnable` once to correct the situation.


## Issue 1.
### Issue 1A - Cloaking previous buffers
##### Description:
  Existing buffers remain uncloaked after running `CloakEnable` in a different buffer.

##### Steps to Reproduce:
1. Open a secrets file in a buffer (the file is cloaked).
2. Run `CloakDisable` (the file is now uncloaked).
3. Switch to a second buffer.
2. Run `CloakEnable`.
4. Switch back to the first buffer.
    - **Expected:** File is cloaked.
    - **Observed:** File is uncloaked, the `Cloak.enabled` status is out of sync with the drawing.

##### Cause:
The `BufRead` event for the cloaking autocmd in `M.setup()` means that only new buffers will be checked, not ones that already exist.

##### Fix:
Use `BufEnter` instead of `BufRead`.


### Issue 1B - Uncloaking previous buffers
##### Description:
Existing buffers remain cloaked after running `CloakDisable` in a different buffer.

##### Steps to Reproduce:
1. Open a secrets file in a buffer (the file is cloaked).
2. Switch to a second buffer.
3. Run `CloakDisable`.
4. Switch back to the first buffer.
    - **Expected:** File is uncloaked.
    - **Observed:** File is cloaked, the `Cloak.enabled` status is out of sync with the drawing.

##### Cause:
- The `BufRead` event for the cloaking autocmd in `M.setup()` means that only new buffers will be checked, not ones that already exist.
- Cloaking is done when entering a matched file, but not uncloaking.

##### Fix:
- Use `BufEnter` instead of `BufRead`.
- Add `else uncloak()` to the autocmd's callback.


### Issue 1 Comments:
The big picture here is that there are no guards for when Cloak's state changes, which will cause problems for existing buffers.


## Issue 2.
### Issue 2A - `CloakPreviewLine` & Split buffers
##### Description:
If you use `CloakPreviewLine` on a cloaked line and then switch buffers in a split, the line remains uncloaked.

##### Steps to Reproduce:
1. Open a standard file in the buffer.
2. Create a split and open a secrets file in the buffer (the file is cloaked).
3. Run `CloakPreviewLine` on a cloaked line.
4. Swap focus to the standard file.
    - **Expected:** Since my cursor has moved off of the line with the secret, it should recloak.
    - **Observed:** The secret remains uncloaked.

##### Cause:
- In the `M.uncloak_line()` autocmd, `uncloaked_line_num` is not cleared when leaving a buffer, only when moving inside the buffer where `CloakPreviewLine` was run.

##### Fix:
- Add `'BufLeave'` to the autocmd's events.
- Update the autocmd with the following check:
```lua
-- Recloak the file when leaving the buffer
if args.event == 'BufLeave' then
  M.opts.uncloaked_line_num = nil
  M.recloak_file(vim.api.nvim_buf_get_name(buf))
  return true
end
```


### Issue 2B - `CloakPreviewLine` & Other buffers
##### Description:
If you use `CloakPreviewLine` and then switch buffers, `uncloaked_line_num` is still set and will leak secrets on the same line number in Telescope / other buffers.

##### Steps to Reproduce:
1. Open a standard file in the buffer.
2. Run `CloakPreviewLine` on any line and make note of the line number.
3. Use Telescope to preview a secrets file.
    - **Expected:** Preview is cloaked.
    - **Observed:** If there is a secret on the same line number as noted, the previewed line will be uncloaked(!).
5. Open the secrets file.
    - **Expected:** File is cloaked.
    - **Observed:** The secret remains leaked (even after moving hjkl). 

##### Cause:
-  In the `M.uncloak_line()` autocmd, `uncloaked_line_num` is not cleared when changing buffers.
- The secret remains leaked even after moving the cursor in the new buffer because the autocmd to clear the line number is only attached to the previous buffer.
- Note: running Disable / Enable will not recloak the file, you either have to rerun `CloakPreviewLine` or move around in the original buffer.


##### Fix:
- Add `'BufLeave'` to the autocmd's events.
- Update the autocmd with the following check:
```lua
-- Clear uncloaked_line_num when changing buffers so we don't leak secrets!
if args.event == 'BufLeave' then
  M.opts.uncloaked_line_num = nil
  --M.recloak_file(vim.api.nvim_buf_get_name(buf))   -- Not necessary for 2B, but required to fix 2A
  return true
end
```

### Issue 2 Comments

The key here is that we want to prevent the value of `uncloaked_line_num` from leaking into other buffers. Currently the state is **only reset when the cursor moves around in the original buffer**. This means that when we jump to a different buffer the value of `uncloaked_line_num` remains and won't be reset unless you rerun the command or go back to the original buffer and move around.



## Issue 3.
##### Description:
If you use `CloakPreviewLine` and then disable Cloak, the `M.uncloak_line()` autocmd is still active and will trigger the next time you move, cloaking the file and making the state of `Cloak.enabled` be out of sync.

##### Steps to Reproduce:
1. Open a secrets file in the buffer (the file is cloaked).
2. Run `CloakPreviewLine` and then while on the same line run `CloakToggle` or `CloakDisable`.
3. Move around with hjkl
    - **Expected:** File remains uncloaked.
    - **Observed:** File recloaks itself and the `Cloak.enabled` status is out of sync with the drawing.

##### Cause:
- The `M.uncloak_line()` autocmd is still active and will recloak the file when triggered regardless of `Cloak.enabled`.

##### Fix:
- Add the following check to the top of the `M.uncloak_line()` autocmd callback:
```lua
if not M.opts.enabled then
  M.opts.uncloaked_line_num = nil
  return true
end
```

### Issue 3 Comments
Imagine: *You open up a secrets file and preview a line but then think to yourself "hm actually, I might as well see the whole thing" and proceed to run `CloakToggle`*

Currently the `M.uncloak_line()` autocmd does not check for the state of Cloak when being run, but thankfully it is an easy fix.

